### PR TITLE
Fix prize board displaying incorrectly

### DIFF
--- a/web/solana.fluidity.money/src/components/Pages/Contents/DashboardContent/InfoGrid.tsx
+++ b/web/solana.fluidity.money/src/components/Pages/Contents/DashboardContent/InfoGrid.tsx
@@ -16,8 +16,8 @@ const InfoGrid = ({ prizeBoard }: infoGrid) => {
       <div className="reward-info-table-column">
         <div className="reward-info-table-header header">Amount</div>
         <div className="reward-info-table-column-container">
-          {prizeBoard.map(({ winning_amount, token_details }) => (
-            <div className="reward-info-table-content" key={winning_amount}>
+          {prizeBoard.map(({ winning_amount, token_details }, i) => (
+            <div className="reward-info-table-content" key={winning_amount + String(i)}>
               $
               {winning_amount === "0"
                 ? "0.000000"
@@ -57,8 +57,8 @@ const InfoGrid = ({ prizeBoard }: infoGrid) => {
       <div className="reward-info-table-column">
         <div className="reward-info-table-header header">Date</div>
         <div className="reward-info-table-column-container">
-          {prizeBoard.map(({ awarded_time }) => (
-            <div className="reward-info-table-content" key={awarded_time}>
+          {prizeBoard.map(({ awarded_time }, i) => (
+            <div className="reward-info-table-content" key={awarded_time + String(i)}>
               {new Date(awarded_time)
                 .toLocaleString()
                 .split("")


### PR DESCRIPTION
Prize board would react poorly to entries having duplicates (e.g. at the same time/of the same amount) due to its use of these values as list keys. Updated list keys to also use array index to ensure uniqueness