### PR TITLE
Add environmental config script to build solana

### DIFF
--- a/web/solana.fluidity.money/env-config.sh
+++ b/web/solana.fluidity.money/env-config.sh
@@ -1,6 +1,8 @@
 export \
 	REACT_APP_API_URL=https://app.solana.beta.fluidity.money:8081 \
-	REACT_APP_WEBSOCKET=wss://app.solana.beta.fluidity.money:8081/updates \
+	REACT_APP_WEBSOCKET=wss://app.solana.beta.fluidity.money:8081/updates	
+        
+export \
 	REACT_APP_FLUID_PROGRAM_ID=HXCKzsLf5ohVEYo5shk7MjhbqeUemwikBj4667aPhmK9 \
 	REACT_APP_FLU_MINT_USDC=5jsh1taLrqNgiV3UN8diDxZAXRC7T4iALfNWwThBksoj \
         REACT_APP_FLU_OBLIGATION_USDC=AzC4PyevxfhrRcY4x7Xm94PQyf9nfjcheLsSiE53Rcy \


### PR DESCRIPTION
- Add public key and API URL environmental config script to build Solana. 
 
Before running ```make watch``` to build, set the environmental variables by running ```source env-config.sh``` or ```. ./env-config.sh```, This will run within the existing shell, ensuring any variables created or modified by the script will be available after the script completes. 