### PR TITLE
Prevent `log.Fatal` from hanging indefinitely

### DIFF
--- a/lib/log/init.go
+++ b/lib/log/init.go
@@ -1,7 +1,9 @@
 package log
 
 import (
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/fluidity-money/fluidity-app/lib"
 )
@@ -14,6 +16,7 @@ func init() {
 		workerId     = os.Getenv(microservice_lib.EnvWorkerId)
 	)
 
+	rand.Seed(time.Now().Unix())
 	invocation := os.Args[0]
 
 	go startLoggingServer(

--- a/lib/log/server.go
+++ b/lib/log/server.go
@@ -45,7 +45,17 @@ func backoff() {
 		"Sleeping for %v seconds...\n",
 		duration.Seconds(),
 	)
-	logMessage(loggingLevelApp, "CrashScheduler", message, "")
+
+	// manually write since the channel is blocked waiting for backoff
+	fmt.Fprintf(
+		loggingStream,
+		"[%v] [%s:%s] %s %v\n",
+		time.Now(),
+		LoggingLevelApp,
+		"CrashScheduler",
+		message,
+		"",
+	)
 	time.Sleep(duration)
 }
 


### PR DESCRIPTION
- also seed rand for use in backoff times