### PR TITLE
refactor: removed stdout logging from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,11 @@ ENV NODE_VERSION=16.13.0
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
+
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-RUN node --version
-RUN npm --version
-
-RUN node --version
 
 WORKDIR ${FLUID_DIR}
 


### PR DESCRIPTION
## Note:
Did a quick experiment with moving NVM to another Dockerfile, but getting weird errors - so not touching that anytime soon.
Also it's nicer for Dockerfile.web to use the same Node version as the root > 12.0.0