### PR TITLE
fix: use known txn hash in explorer link

### DIFF
--- a/web/solana.fluidity.money/src/components/Modal/Themes/TransactionConfirmationModal.tsx.tsx
+++ b/web/solana.fluidity.money/src/components/Modal/Themes/TransactionConfirmationModal.tsx.tsx
@@ -1,19 +1,18 @@
 import Button from "components/Button";
-import { UserActionContext } from "components/context";
 import GenericModal from "components/Modal/GenericModal";
-import { useContext } from "react";
 import { solExplorer } from "util/solana/solExplorer";
 
 const TransactionConfirmationModal = ({
   enable,
   toggle,
   message,
+  transactionHash,
 }: {
   enable: boolean;
   toggle: () => void;
   message: React.ReactNode;
+  transactionHash?: string;
 }) => {
-  const userActions = useContext(UserActionContext);
   return (
     <GenericModal enable={enable} toggle={toggle}>
       <div className="modal-body transaction-confirmation-modal-form">
@@ -45,8 +44,8 @@ const TransactionConfirmationModal = ({
           className="view-on-explorer"
           target="_blank"
           href={
-            userActions.length
-              ? solExplorer(userActions[0].transaction_hash, "tx")
+           transactionHash 
+              ? solExplorer(transactionHash, "tx")
               : "https://explorer.solana.com/?cluster=devnet"
           }
           rel="noreferrer"

--- a/web/solana.fluidity.money/src/components/Pages/Contents/SwapPage/SwapBox.tsx
+++ b/web/solana.fluidity.money/src/components/Pages/Contents/SwapPage/SwapBox.tsx
@@ -33,6 +33,7 @@ const SwapBox = () => {
   const [successTransactionModal, setSuccessTransactionModal] = useState<boolean>(false); // toggle state for the transaction confirmation
   const [balance, setBalance] = useState("0");  // state to track status of selected fluid amount in wallet
   const [fbalance, setfBalance] = useState("0");  // state to track amount of selected standard token in wallet
+  const [previousTransactionHash, setPreviousTransactionHash] = useState(""); 
 
   const {tokens} = useFluidTokens();
   const sol = useSolana();
@@ -211,6 +212,8 @@ const SwapBox = () => {
       }
 
       console.log(result);
+      setPreviousTransactionHash(result);
+
       toggleSuccessTransactionModal();
       switchPayment();
     } catch (e) {
@@ -394,6 +397,7 @@ const SwapBox = () => {
               message={
                 <div className="primary-text">Transaction Successful</div>
               }
+              transactionHash={previousTransactionHash}
             />
           </FormSection>
         </div>

--- a/web/solana.fluidity.money/src/components/Pages/Contents/WalletPage/SendFluid.tsx
+++ b/web/solana.fluidity.money/src/components/Pages/Contents/WalletPage/SendFluid.tsx
@@ -37,6 +37,7 @@ const SendFluid = () => {
   const [address, setAddress] = useState("");
   const [successTransactionModal, setSuccessTransactionModal] =
     useState<boolean>(false); // toggle state for the transaction confirmation
+  const [previousTransactionHash, setPreviousTransactionHash] = useState(""); 
 
   // userActions context to update balance when potentially sending/receiving
   const userActions = useContext(UserActionContext);
@@ -101,7 +102,11 @@ const SendFluid = () => {
         new TokenAmount(tokens[selectedFluidToken].token, toRaw),
         addError
       );
+
       console.log(result);
+
+      if (result)
+        setPreviousTransactionHash(result);
       toggleSuccessTransactionModal();
     } catch (e: any) {
       addError(`Failed to send tokens! ${e?.message}`);
@@ -238,6 +243,7 @@ const SendFluid = () => {
           enable={successTransactionModal}
           toggle={toggleSuccessTransactionModal}
           message={<div className="primary-text">Transaction Successful</div>}
+          transactionHash={previousTransactionHash}
         />
       </div>
     </ModalToggle.Provider>


### PR DESCRIPTION
- fix transaction success modals using empty/incorrect hash by passing as prop rather than relying on user actions