### PR TITLE
fix: pin dev timescale version

### DIFF
--- a/database/Dockerfile.timescale
+++ b/database/Dockerfile.timescale
@@ -1,5 +1,5 @@
 
-FROM timescale/timescaledb:latest-pg12
+FROM timescale/timescaledb:2.8.0-pg12
 
 ENV REPO /usr/src/fluidity-migrations-timescale
 


### PR DESCRIPTION
- pin version to `2.8.0` to support using months and years in `time_bucket`