### PR TITLE
fix deprecated warning from gh workflow due to set-output

### DIFF
--- a/.github/workflows/mainnet-auto.yml
+++ b/.github/workflows/mainnet-auto.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 2
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/mainnet-db-migration-auto.yml
+++ b/.github/workflows/mainnet-db-migration-auto.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/mainnet-db-migration-manual.yml
+++ b/.github/workflows/mainnet-db-migration-manual.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/mainnet-manual.yml
+++ b/.github/workflows/mainnet-manual.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -64,7 +64,7 @@ jobs:
           lfs: true
           ref: ${{ github.event.inputs.rollbackTo }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/staging-auto.yml
+++ b/.github/workflows/staging-auto.yml
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 2
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/staging-db-migration-manual.yml
+++ b/.github/workflows/staging-db-migration-manual.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}

--- a/.github/workflows/staging-manual.yml
+++ b/.github/workflows/staging-manual.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lfs: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.FLU_AWS_GITHUB_OIDC_ROLE }}


### PR DESCRIPTION
Complete warning statement from Github:

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/