### PR TITLE
display swaps in tx list, don't double show rewards

### DIFF
--- a/web/app.fluidity.money/app/types/Transaction.ts
+++ b/web/app.fluidity.money/app/types/Transaction.ts
@@ -11,6 +11,7 @@ type Transaction = {
   currency: string;
   logo: string;
   provider: string;
+  swapType?: "in" | "out"
 };
 
 export default Transaction;

--- a/web/app.fluidity.money/app/util/converters.ts
+++ b/web/app.fluidity.money/app/util/converters.ts
@@ -106,10 +106,13 @@ const trimAddress = (address: string): string => {
 };
 
 const transactionActivityLabel = (
-  activity: { sender: string; currency: string; [key: string]: unknown },
+  activity: { sender: string; currency: string; swapType?: "in" | "out"; [key: string]: unknown },
   address: string
 ) => {
-  const { sender, currency } = activity;
+  const { sender, currency, swapType } = activity;
+  if (swapType)
+    return swapType === "in" ? `Fluidified ${currency}` : `Unfluidified ${currency}`;
+
   return sender === address ? `Sent ${currency}` : `Received ${currency}`;
 };
 

--- a/web/app.fluidity.money/app/util/converters.ts
+++ b/web/app.fluidity.money/app/util/converters.ts
@@ -111,7 +111,7 @@ const transactionActivityLabel = (
 ) => {
   const { sender, currency, swapType } = activity;
   if (swapType)
-    return swapType === "in" ? `Fluidified ${currency}` : `Unfluidified ${currency}`;
+    return swapType === "in" ? `Fluidified ${currency}` : `Reverted ${currency}`;
 
   return sender === address ? `Sent ${currency}` : `Received ${currency}`;
 };


### PR DESCRIPTION
- filter rewards from transactions list so they only appear as part of the transaction(/s) that caused them
- distinguish swaps in/out in transactions list, and show the address that performed the swap