### PR TITLE
`npm ci` is dangerous for multiplatform/multiarch

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -17,8 +17,6 @@ npm run dev
 ```
 
 in _this_ folder and it should all be live.
-Things aren't working? Run `npm ci` from the root and it should pull all
-the stuff you need from the lockfile.
 
 ## Package management
 Is it a shared package such as React? An npm install in the root should do.

--- a/web/app.fluidity.money/Dockerfile.frontend
+++ b/web/app.fluidity.money/Dockerfile.frontend
@@ -8,7 +8,7 @@ ENV PATH /app/node_modules.bin:$PATH
 
 COPY . ./
 
-RUN npm ci
+RUN npm i
 
 ARG REACT_APP_SENTRY_DSN
 

--- a/web/fluidity.money/Dockerfile.frontend
+++ b/web/fluidity.money/Dockerfile.frontend
@@ -19,7 +19,7 @@ COPY . ./
 
 RUN ls
 
-RUN npm ci
+RUN npm i
 
 
 ARG REACT_APP_SENTRY_DSN


### PR DESCRIPTION
Replacing due to the wrong `turbo` binary being pulled. Could be mitigated with an NPM install of the problem package prior but don't want to set that precedent.