### PR TITLE
use fee switch in user actions

### DIFF
--- a/cmd/microservice-ethereum-worker-server/database.go
+++ b/cmd/microservice-ethereum-worker-server/database.go
@@ -5,11 +5,9 @@
 package main
 
 import (
-	postgres "github.com/fluidity-money/fluidity-app/lib/databases/postgres/worker"
 	"github.com/fluidity-money/fluidity-app/lib/databases/timescale/worker"
 	timescale "github.com/fluidity-money/fluidity-app/lib/databases/timescale/worker"
 	"github.com/fluidity-money/fluidity-app/lib/log"
-	"github.com/fluidity-money/fluidity-app/lib/types/ethereum"
 	"github.com/fluidity-money/fluidity-app/lib/types/network"
 )
 
@@ -36,14 +34,4 @@ func computeTransactionsSumAndAverage(network_ network.BlockchainNetwork, tokenS
 		network_,
 		limit,
 	)
-}
-
-func lookupFeeSwitch(addr ethereum.Address, network_ network.BlockchainNetwork) ethereum.Address {
-	feeSwitch := postgres.GetFeeSwitch(addr, network_)
-
-	if feeSwitch == nil {
-		return addr
-	}
-
-	return feeSwitch.NewAddress
 }

--- a/cmd/microservice-ethereum-worker-server/main.go
+++ b/cmd/microservice-ethereum-worker-server/main.go
@@ -378,8 +378,8 @@ func main() {
 				)
 
 				var (
-					senderAddress    = lookupFeeSwitch(senderAddress_, dbNetwork)
-					recipientAddress = lookupFeeSwitch(recipientAddress_, dbNetwork)
+					senderAddress    = worker_config.LookupFeeSwitch(senderAddress_, dbNetwork)
+					recipientAddress = worker_config.LookupFeeSwitch(recipientAddress_, dbNetwork)
 				)
 
 				application := applications.ApplicationNone

--- a/lib/databases/postgres/worker/fee-switch.go
+++ b/lib/databases/postgres/worker/fee-switch.go
@@ -78,3 +78,14 @@ func GetFeeSwitch(originalAddress ethereum.Address, network_ network.BlockchainN
 
 	return &feeSwitch
 }
+
+// LookupFeeSwitch to get the fee switch for the given address, or the address if no switch is found
+func LookupFeeSwitch(addr ethereum.Address, network_ network.BlockchainNetwork) ethereum.Address {
+	feeSwitch := GetFeeSwitch(addr, network_)
+
+	if feeSwitch == nil {
+		return addr
+	}
+
+	return feeSwitch.NewAddress
+}


### PR DESCRIPTION
- track transfers via their fee switched address
- only applies to networks utilising both fee switches and `microservice-ethereum-user-actions`