### PR TITLE
track non `Transfer` events in lootbox microservice

### DIFF
--- a/cmd/microservice-ethereum-application-server/main.go
+++ b/cmd/microservice-ethereum-application-server/main.go
@@ -232,7 +232,7 @@ func main() {
 			transfersWithFees := make([]worker.EthereumDecoratedTransfer, 0)
 
 			for _, transfer := range transfers {
-				fee, emission, err := applications.GetApplicationFee(
+				feeData, emission, err := applications.GetApplicationFee(
 					transfer,
 					gethClient,
 					contractAddress,
@@ -240,6 +240,8 @@ func main() {
 					*convertedReceipt,
 					transaction.Data,
 				)
+
+				fee := feeData.Fee
 
 				if err != nil {
 					log.Fatal(func(k *log.Log) {

--- a/cmd/microservice-ethereum-application-server/main.go
+++ b/cmd/microservice-ethereum-application-server/main.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -19,7 +17,6 @@ import (
 	"github.com/fluidity-money/fluidity-app/lib/types/ethereum"
 	"github.com/fluidity-money/fluidity-app/lib/util"
 
-	"github.com/ethereum/go-ethereum/common"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -44,32 +41,6 @@ const (
 	EnvServerWorkQueue = `FLU_ETHEREUM_WORK_QUEUE`
 )
 
-func getReceipt(gethClient *ethclient.Client, transactionHash ethereum.Hash) (*ethereum.Receipt, error) {
-	txReceipt, err := gethClient.TransactionReceipt(
-		context.Background(),
-		common.HexToHash(transactionHash.String()),
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Failed to get the transaction receipt for Fluid transfer %#v! %w",
-			transactionHash.String(),
-			err,
-		)
-	}
-
-	if txReceipt == nil {
-		return nil, fmt.Errorf(
-			"Receipt for fluid transfer %v was nil! %w",
-			transactionHash,
-			err,
-		)
-	}
-
-	convertedReceipt := libEthereum.ConvertGethReceipt(*txReceipt)
-
-	return &convertedReceipt, nil
-}
 
 // appsListFromEnvOrFatal parses a list of `app:address:address,app:address:address` into a map of {address => app}
 func appsListFromEnvOrFatal(key string) map[ethereum.Address]appTypes.Application {
@@ -245,7 +216,7 @@ func main() {
 				})
 			}
 
-			convertedReceipt, err := getReceipt(gethClient, transactionHash)
+			convertedReceipt, err := libEthereum.GetReceipt(gethClient, transactionHash)
 
 			if err != nil {
 				log.Fatal(func(k *log.Log) {
@@ -358,7 +329,7 @@ func main() {
 
 				decoratedTransaction.Transaction = transaction
 
-				receipt, err := getReceipt(gethClient, transactionHash)
+				receipt, err := libEthereum.GetReceipt(gethClient, transactionHash)
 
 				if err != nil {
 					log.Fatal(func(k *log.Log) {

--- a/cmd/microservice-ethereum-create-transaction-lootboxes/README.md
+++ b/cmd/microservice-ethereum-create-transaction-lootboxes/README.md
@@ -11,6 +11,8 @@ and publishes to lootbox queue
 | `FLU_DEBUG`           | Toggle debug messages produced by any application using the debug logger.    |
 | `FLU_AMQP_QUEUE_ADDR` | AMQP queue address connected to to receive and send messages down.           |
 | `FLU_TIMESCALE_URI`   | Database URI to use when connecting to the Timescale database.               |
+| `FLU_ETHEREUM_TOKENS_LIST` | List of tokens in address:shortname:decimals form to look up addresses from a short name |
+| `FLU_ETHEREUM_HTTP_URL` | URL to use to chat to an Ethereum RPC node. |
 
 ## Building
 

--- a/cmd/microservice-ethereum-create-transaction-lootboxes/main.go
+++ b/cmd/microservice-ethereum-create-transaction-lootboxes/main.go
@@ -41,7 +41,8 @@ func main() {
 		ethereumTokensList_ = util.GetEnvOrFatal(EnvTokensList)
 		gethHttpUrl         = util.GetEnvOrFatal(EnvGethHttpUrl)
 
-		volume misc.BigInt
+		volumeBigInt misc.BigInt
+		volume *big.Rat
 	)
 
 	tokensList := util.GetTokensListBase(ethereumTokensList_)
@@ -172,14 +173,42 @@ func main() {
 				})
 			}
 
-			// volume is a uint256, so no denom
-			volume = misc.NewBigIntFromInt(*feeData.Volume.Num())
+			// keep volume as is to do calculations with
+			volume = new(big.Rat).Set(feeData.Volume)
+
+			// volumeBigInt_ to convert to the database BigInt
+			// volumeBigInt_ = (volumeRat * 10^decimals * denominator)::BigInt / denominator
+			// this is to convert to a BigInt without losing decimal places that are relevant to the token amount
+			// e.g. 1234567/100000 with 6 decimals should be adjusted to 12345670
+			volumeBigInt_ := new(big.Rat).Set(feeData.Volume)
+
+			decimalsAdjusted := math.Pow10(tokenDecimals)
+			decimalsRat := new(big.Rat).SetFloat64(decimalsAdjusted)
+
+			// get denominator
+			denom := new(big.Int).Set(volumeBigInt_.Denom())
+			// multiply by decimals
+			volumeBigInt_ = volumeBigInt_.Mul(volumeBigInt_, decimalsRat)
+			// multiply by denom to get number as an int
+			volumeBigInt_ = volumeBigInt_.Mul(volumeBigInt_, new(big.Rat).SetInt(denom))
+			// convert to int
+			volumeBigIntNum := volumeBigInt_.Num()
+
+			// divide by original denom, losing any extra precision
+			volumeBigIntNum = volumeBigIntNum.Quo(volumeBigIntNum, denom)
+			volumeBigInt = misc.NewBigIntFromInt(*volumeBigIntNum)
+			
 		} else {
-			volume = sendTransaction.Amount
+			volumeBigInt = sendTransaction.Amount
+			// adjust to USD
+			volume = new(big.Rat).SetInt(&sendTransaction.Amount.Int)
+			decimalsAdjusted := math.Pow10(tokenDecimals)
+			decimalsRat := new(big.Rat).SetFloat64(decimalsAdjusted)
+			volume = volume.Quo(volume, decimalsRat)
 		}
 
 		// Calculate lootboxes earned from transaction
-		// ((volume / (10 ^ token_decimals)) / 3) + calculate_a_y(address, awarded_time)) * protocol_multiplier(ethereum_application) / 100
+		// ((volume) / 3) + calculate_a_y(address, awarded_time)) * protocol_multiplier(ethereum_application) / 100
 		lootboxCount := new(big.Rat).Mul(
 			volumeLiquidityMultiplier(
 				volume,
@@ -208,7 +237,7 @@ func main() {
 			Source:          lootboxes.Transaction,
 			TransactionHash: transactionHash,
 			AwardedTime:     awardedTime,
-			Volume:          volume,
+			Volume:          volumeBigInt,
 			RewardTier:      rewardTier,
 			LootboxCount:    lootboxCountFloat,
 			Application:     application,
@@ -218,13 +247,9 @@ func main() {
 	})
 }
 
-func volumeLiquidityMultiplier(volume misc.BigInt, tokenDecimals int, address string, time time.Time) *big.Rat {
-	volumeLiquidityNum := new(big.Rat).SetInt(&volume.Int)
-
-	tokenDecimalsRat := new(big.Rat).SetFloat64(math.Pow10(tokenDecimals) * 3)
-	volumeLiquidityDenom := new(big.Rat).Inv(tokenDecimalsRat)
-
-	volumeLiquidityRat := new(big.Rat).Mul(volumeLiquidityNum, volumeLiquidityDenom)
+func volumeLiquidityMultiplier(volume *big.Rat, tokenDecimals int, address string, time time.Time) *big.Rat {
+	three := big.NewRat(3, 1)
+	volumeLiquidityRat := new(big.Rat).Quo(volume, three)
 
 	liquidityMultiplier := new(big.Rat).SetFloat64(database.Calculate_A_Y(address, time))
 

--- a/common/ethereum/applications/applications_test.go
+++ b/common/ethereum/applications/applications_test.go
@@ -27,50 +27,50 @@ func TestGetApplicationFee(t *testing.T) {
 		inputData          misc.Blob
 	)
 
-	fee, emission, err := GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err := GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationUniswapV2
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationBalancerV2
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationOneInchLPV1
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationMooniswap
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationOneInchFixedRateSwap
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationCurve
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 
 	transfer.Application = ApplicationMultichain
-	fee, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
-	assert.Nil(t, fee)
+	feeData, emission, err = GetApplicationFee(transfer, client, fluidTokenContract, tokenDecimals, receipt, inputData)
+	assert.Nil(t, feeData.Fee)
 	assert.Zero(t, emission)
 	assert.Error(t, err)
 }

--- a/common/ethereum/applications/balancer/balancer_test.go
+++ b/common/ethereum/applications/balancer/balancer_test.go
@@ -82,9 +82,9 @@ func TestGetBalancerFees(t *testing.T) {
 	assert.NoError(t, err)
 
 	// nil transfer fails
-	fees, err := GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err := GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	transfer.Log.Topics = []ethTypes.Hash{
 		ethTypes.HashFromString(""),
@@ -94,28 +94,28 @@ func TestGetBalancerFees(t *testing.T) {
 	}
 
 	// nil data fails with no error (topics don't match)
-	fees, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// fluid -> other successful
 	transfer.Log.Data = *dataBlob
 	transfer.Log.Topics[0] = ethTypes.HashFromString(balancerSwapLogTopic)
-	fees, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, big.NewRat(25, 1), fees)
+	assert.Equal(t, big.NewRat(25, 1), feeData.Fee)
 
 	// other -> fluid successful
 	transfer.Log.Topics[2] = ethTypes.HashFromString("0x2")
-	fees, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, big.NewRat(7340032, 309375), fees)
+	assert.Equal(t, big.NewRat(7340032, 309375), feeData.Fee)
 
 	// other -> other successful
 	transfer.Log.Topics[3] = ethTypes.HashFromString("0x3")
-	fees, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// bad RPC responses
 	// bad swap fee response
@@ -125,8 +125,8 @@ func TestGetBalancerFees(t *testing.T) {
 	client, err = testUtils.MockRpcClient(rpcMethods, callMethods)
 	assert.NoError(t, err)
 
-	fees, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
-	assert.Nil(t, fees)
+	feeData, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	assert.Nil(t, feeData.Fee)
 	assert.Error(t, err)
 
 	// bad pool response
@@ -136,7 +136,7 @@ func TestGetBalancerFees(t *testing.T) {
 	client, err = testUtils.MockRpcClient(rpcMethods, callMethods)
 	assert.NoError(t, err)
 
-	fees, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
-	assert.Nil(t, fees)
+	feeData, err = GetBalancerFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	assert.Nil(t, feeData.Fee)
 	assert.Error(t, err)
 }

--- a/common/ethereum/applications/curve/curve_test.go
+++ b/common/ethereum/applications/curve/curve_test.go
@@ -60,9 +60,9 @@ func TestGetCurveSwapFee(t *testing.T) {
 	assert.NoError(t, err)
 
 	// nil transfer fails
-	fees, err := GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err := GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	transfer.Log.Topics = []ethTypes.Hash{
 		ethTypes.HashFromString(""),
@@ -72,22 +72,22 @@ func TestGetCurveSwapFee(t *testing.T) {
 	}
 
 	// nil data fails with no error (wrong topic)
-	fees, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// fluid -> other successful
 	transfer.Log.Data = *dataBlob
 	transfer.Log.Topics[0] = ethTypes.HashFromString(curveTokenExchangeLogTopic)
-	fees, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, big.NewRat(2771439, 2500000000), fees)
+	assert.Equal(t, big.NewRat(2771439, 2500000000), feeData.Fee)
 
 	// other -> other successful
 	fluidTokenAddr = common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
-	fees, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// bad RPC responses
 	// bad swap fee response
@@ -98,8 +98,8 @@ func TestGetCurveSwapFee(t *testing.T) {
 	client, err = testUtils.MockRpcClient(rpcMethods, callMethods)
 	assert.NoError(t, err)
 
-	fees, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
-	assert.Nil(t, fees)
+	feeData, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	assert.Nil(t, feeData.Fee)
 	assert.Error(t, err)
 
 	// bad coins response
@@ -112,8 +112,8 @@ func TestGetCurveSwapFee(t *testing.T) {
 	client, err = testUtils.MockRpcClient(rpcMethods, callMethods)
 	assert.NoError(t, err)
 
-	fees, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
-	assert.Nil(t, fees)
+	feeData, err = GetCurveSwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	assert.Nil(t, feeData.Fee)
 	assert.Error(t, err)
 }
 

--- a/common/ethereum/applications/gtrade/gtrade_test.go
+++ b/common/ethereum/applications/gtrade/gtrade_test.go
@@ -66,9 +66,9 @@ func TestGetGTrade_v6_1SwapFee(t *testing.T) {
 	assert.NoError(t, err)
 
 	// nil transfer fails
-	fees, err := GetGtradeV6_1Fees(transfer, client, fluidTokenAddr, tokenDecimals, txReceipt)
+	feeData, err := GetGtradeV6_1Fees(transfer, client, fluidTokenAddr, tokenDecimals, txReceipt)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	transfer.Log.Topics = []ethTypes.Hash{
 		ethTypes.HashFromString(""),
@@ -113,13 +113,13 @@ func TestGetGTrade_v6_1SwapFee(t *testing.T) {
 		transferLog2,
 	)
 
-	fees, err = GetGtradeV6_1Fees(transfer, client, fluidTokenAddr, tokenDecimals, txReceipt)
+	feeData, err = GetGtradeV6_1Fees(transfer, client, fluidTokenAddr, tokenDecimals, txReceipt)
 	assert.NoError(t, err)
-	assert.Equal(t, big.NewRat(6174090953184000000, 1000000000000000000), fees)
+	assert.Equal(t, big.NewRat(6174090953184000000, 1000000000000000000), feeData.Fee)
 
 	// Non-Fluid transfer
 	fluidTokenAddr = common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
-	fees, err = GetGtradeV6_1Fees(transfer, client, fluidTokenAddr, tokenDecimals, txReceipt)
+	feeData, err = GetGtradeV6_1Fees(transfer, client, fluidTokenAddr, tokenDecimals, txReceipt)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 }

--- a/common/ethereum/applications/multichain/multichain_test.go
+++ b/common/ethereum/applications/multichain/multichain_test.go
@@ -51,9 +51,9 @@ func TestGetMultichainAnySwapFee(t *testing.T) {
 	assert.NoError(t, err)
 
 	// nil transfer fails
-	fees, err := GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err := GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	transfer.Log.Topics = []ethTypes.Hash{
 		ethTypes.HashFromString(""),
@@ -63,22 +63,22 @@ func TestGetMultichainAnySwapFee(t *testing.T) {
 	}
 
 	// nil data fails with no error (wrong topic)
-	fees, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// fluid -> other successful
 	transfer.Log.Data = *dataBlob
 	transfer.Log.Topics[0] = ethTypes.HashFromString(multichainLogAnySwapOut)
-	fees, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, big.NewRat(40, 1), fees)
+	assert.Equal(t, big.NewRat(40, 1), feeData.Fee)
 
 	// other -> other successful
 	fluidTokenAddr = common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
-	fees, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Nil(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// bad RPC responses
 	// bad underlying response
@@ -88,8 +88,8 @@ func TestGetMultichainAnySwapFee(t *testing.T) {
 	client, err = testUtils.MockRpcClient(rpcMethods, callMethods)
 	assert.NoError(t, err)
 
-	fees, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
-	assert.Nil(t, fees)
+	feeData, err = GetMultichainAnySwapFees(transfer, client, fluidTokenAddr, tokenDecimals)
+	assert.Nil(t, feeData.Fee)
 	assert.Error(t, err)
 }
 

--- a/common/ethereum/applications/uniswap/uniswap_test.go
+++ b/common/ethereum/applications/uniswap/uniswap_test.go
@@ -43,18 +43,18 @@ func TestGetUniswapV2Fees(t *testing.T) {
 	assert.NoError(t, err)
 
 	// nil transfer fails
-	fees, err := GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err := GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// fails without proper rpc responses
 	transfer.Log.Data = *dataBlob
 	transfer.Log.Topics = []ethereum.Hash{
 		ethereum.HashFromString(uniswapV2SwapLogTopic),
 	}
-	fees, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// add the "token0" call to the client
 	callMethods["token0()"] = map[string]interface{}{
@@ -71,17 +71,17 @@ func TestGetUniswapV2Fees(t *testing.T) {
 	r, ok := new(big.Rat).SetString("4976280438497449851783/500000000000000000000")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 
 	tokenDecimals = 6
 	r, ok = new(big.Rat).SetString("9934320933/997000000")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
+	feeData, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 
 	// transfer 333,333,333
 	err = dataBlob.UnmarshalJSON([]byte(dataBlobB64_2))
@@ -91,9 +91,9 @@ func TestGetUniswapV2Fees(t *testing.T) {
 	r, ok = new(big.Rat).SetString("999999999/1000000000")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
+	feeData, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 
 	// transfer 333,333,333 the other way
 	err = dataBlob.UnmarshalJSON([]byte(dataBlobB64_3))
@@ -103,9 +103,9 @@ func TestGetUniswapV2Fees(t *testing.T) {
 	r, ok = new(big.Rat).SetString("39893259/39880000")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetUniswapV2Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 }
 
 func TestGetUniswapV3Fees(t *testing.T) {
@@ -135,18 +135,18 @@ func TestGetUniswapV3Fees(t *testing.T) {
 	assert.NoError(t, err)
 
 	// nil transfer fails
-	fees, err := GetUniswapV3Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err := GetUniswapV3Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// fails without proper rpc responses
 	transfer.Log.Data = *dataBlob
 	transfer.Log.Topics = []ethereum.Hash{
 		ethereum.HashFromString(uniswapV3SwapLogTopic),
 	}
-	fees, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.Error(t, err)
-	assert.Nil(t, fees)
+	assert.Nil(t, feeData.Fee)
 
 	// add the "token0" call to the client
 	callMethods["token0()"] = map[string]interface{}{
@@ -166,17 +166,17 @@ func TestGetUniswapV3Fees(t *testing.T) {
 	r, ok := new(big.Rat).SetString("71/100")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr, tokenDecimals)
+	feeData, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 
 	tokenDecimals = 6
 	r, ok = new(big.Rat).SetString("1774825271/2499750000")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
+	feeData, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 
 	// transfer 333,333,333
 	err = dataBlob.UnmarshalJSON([]byte(dataBlobB64_2))
@@ -186,7 +186,7 @@ func TestGetUniswapV3Fees(t *testing.T) {
 	r, ok = new(big.Rat).SetString("333333333/10000000000")
 	assert.True(t, ok)
 
-	fees, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
+	feeData, err = GetUniswapV3Fees(transfer, client, fluidTokenAddr2, tokenDecimals)
 	assert.NoError(t, err)
-	assert.Equal(t, r, fees)
+	assert.Equal(t, r, feeData.Fee)
 }

--- a/common/ethereum/util.go
+++ b/common/ethereum/util.go
@@ -11,9 +11,11 @@ import (
 
 	ethAbi "github.com/ethereum/go-ethereum/accounts/abi"
 	ethBind "github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
+	"github.com/fluidity-money/fluidity-app/lib/types/ethereum"
 	"github.com/fluidity-money/fluidity-app/lib/types/misc"
 )
 
@@ -284,6 +286,33 @@ func StaticCall(client *ethClient.Client, address ethCommon.Address, abi ethAbi.
 	}
 
 	return results, nil
+}
+
+func GetReceipt(gethClient *ethClient.Client, transactionHash ethereum.Hash) (*ethereum.Receipt, error) {
+	txReceipt, err := gethClient.TransactionReceipt(
+		context.Background(),
+		common.HexToHash(transactionHash.String()),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Failed to get the transaction receipt for Fluid transfer %#v! %w",
+			transactionHash.String(),
+			err,
+		)
+	}
+
+	if txReceipt == nil {
+		return nil, fmt.Errorf(
+			"Receipt for fluid transfer %v was nil! %w",
+			transactionHash,
+			err,
+		)
+	}
+
+	convertedReceipt := ConvertGethReceipt(*txReceipt)
+
+	return &convertedReceipt, nil
 }
 
 // CalculateEffectiveGasPrice with baseFeePerGas + min(maxFeePerGas -

--- a/lib/databases/timescale/user-actions/user-actions.go
+++ b/lib/databases/timescale/user-actions/user-actions.go
@@ -385,7 +385,7 @@ func GetUserActions(f func(userAction UserAction)) {
 }
 
 // GetUserActionByLogIndex to find a user action in a transaction that has the given log index
-func GetUserActionByLogIndex(network network.BlockchainNetwork, transactionHash string, logIndex misc.BigInt) user_actions.UserAction {
+func GetUserActionByLogIndex(network network.BlockchainNetwork, transactionHash string, logIndex misc.BigInt) *user_actions.UserAction {
 	timescaleClient := timescale.Client()
 
 	statementText := fmt.Sprintf(
@@ -440,6 +440,10 @@ func GetUserActionByLogIndex(network network.BlockchainNetwork, transactionHash 
 	)
 
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil 
+		}
+
 		log.Fatal(func(k *log.Log) {
 			k.Context = Context
 			k.Format(
@@ -452,5 +456,5 @@ func GetUserActionByLogIndex(network network.BlockchainNetwork, transactionHash 
 		})
 	}
 
-	return userAction
+	return &userAction
 }

--- a/lib/types/applications/applications.go
+++ b/lib/types/applications/applications.go
@@ -4,7 +4,10 @@
 
 package applications
 
-import "fmt"
+import (
+	"fmt"
+	"math/big"
+)
 
 // applications contains types relevant to supporting events generated
 // via interaction with external applications
@@ -39,6 +42,13 @@ type UtilityName string
 
 // UtilityFluid is the special utility name for the fluid token itself
 var UtilityFluid UtilityName = "FLUID"
+
+type ApplicationFeeData = struct {
+	// Fee for the fee paid to the application (in USD)
+	Fee    *big.Rat `json:"fee"`
+	// Volume for the amount of fluid token used (in USD)
+	Volume *big.Rat `json:"volume"`
+}
 
 func (app Application) String() string {
 	return applicationNames[app]

--- a/lib/types/lootboxes/lootboxes.go
+++ b/lib/types/lootboxes/lootboxes.go
@@ -25,7 +25,7 @@ type Lootbox struct {
 	// AwardedTime of the winning transaction
 	AwardedTime time.Time `json:"awarded_time"`
 
-	// Volume that was swapped or sent
+	// Volume that was swapped or sent in native token units
 	// Volume of 0 indicates no transaction attached
 	Volume misc.BigInt `json:"volume"`
 

--- a/tests/integrations/ethereum/main_test.go
+++ b/tests/integrations/ethereum/main_test.go
@@ -152,7 +152,7 @@ func TestIntegrations(t *testing.T) {
 			convertedReceipt = common.ConvertGethReceipt(*txReceipt)
 		}
 
-		fees, emission, err := applications.GetApplicationFee(
+		feeData, emission, err := applications.GetApplicationFee(
 			transfer,
 			client,
 			fluidAddress,
@@ -173,7 +173,7 @@ func TestIntegrations(t *testing.T) {
 		// correct fees
 		expectedFeesRat, ok := new(big.Rat).SetString(event.ExpectedFees)
 		assert.True(t, ok)
-		assert.Equal(t, expectedFeesRat, fees)
+		assert.Equal(t, expectedFeesRat, feeData.Fee)
 
 		// correct emission
 		assert.Equal(t, event.ExpectedEmission, emission)


### PR DESCRIPTION
- return a struct from `GetApplicationFee` that includes fluid volume
- use `GetApplicationFee` in `create-transaction-lootboxes` to fetch volume if event is not a Transfer

**Unimplemented**
- meson, gtrade aren't included in `GetApplicationFee` volume (they return 0 regardless of actual volume)
- application tests do not test for volume calculation