### PR TITLE
prevent slow loading of transaction pages by caching prize pool

### DIFF
--- a/web/app.fluidity.money/app/routes/$network/dashboard/home.tsx
+++ b/web/app.fluidity.money/app/routes/$network/dashboard/home.tsx
@@ -149,7 +149,7 @@ export default function Home() {
 
   const userHomeData = useFetcher();
   const userTransactionsData = useFetcher();
-  const prizePoolData = useFetcher();
+  const prizePoolData = useCache<{totalPrizePool: number}>(`/${network}/query/dashboard/prizePool`);
 
   const toolTip = useToolTip();
 
@@ -171,10 +171,6 @@ export default function Home() {
         />
       );
   };
-
-  useEffect(() => {
-    prizePoolData.load(`/${network}/query/dashboard/prizePool`);
-  }, []);
 
   useEffect(() => {
     if (!address) return;


### PR DESCRIPTION
- prize pool reloads on every page transition, so use a cached query to prevent long load times