### PR TITLE
solana connector use `blockSubscribe`

### DIFF
--- a/cmd/connector-solana-amqp/README.md
+++ b/cmd/connector-solana-amqp/README.md
@@ -1,7 +1,7 @@
 
 # connector-solana-amqp
 
-Relays transaction logs from the Solana websocket down AMQP.
+Relays transaction logs from the Solana websocket down AMQP. Uses Solana's `blockSubscribe` websocket endpoint to filter for blocks containing relevant transactions. As `blockSubscribe` only supports single addresses, a websocket connection is maintained for each token, with each keeping track of its last seen block for catchup in the event of a crash. To avoid double-sending blocks which contain multiple of the supported tokens, a ring buffer is maintained in Redis which stores previously seen blocks from any websocket.
 
 ## Environment variables
 
@@ -12,6 +12,7 @@ Relays transaction logs from the Solana websocket down AMQP.
 | `FLU_AMQP_QUEUE_ADDR`      | AMQP queue address connected to to receive and send messages down.           |
 | `FLU_SOLANA_WS_URL`        | Solana node websocket address to receive logs subscriptions from.            |
 | `FLU_SOLANA_STARTING_SLOT` | Slot to search from, or `latest`, or empty to use last seen in redis.        |
+| `FLU_SOLANA_TOKENS_LIST`   | Tokens list for the addresses to filter for.                                 |
 | `FLU_REDIS_ADDR`           | Hostname to connect to for the Redis (state) codebase.                       |
 | `FLU_REDIS_PASSWORD`       | Password to use when connecting to the Redis host.                           |
 

--- a/cmd/connector-solana-amqp/main.go
+++ b/cmd/connector-solana-amqp/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/fluidity-money/fluidity-app/lib/log"
 	"github.com/fluidity-money/fluidity-app/lib/state"
 
-	// types "github.com/fluidity-money/fluidity-app/lib/types/solana"
 	"github.com/fluidity-money/fluidity-app/lib/util"
 
 	"github.com/fluidity-money/fluidity-app/cmd/connector-solana-amqp/lib/redis"
@@ -30,9 +29,6 @@ const (
 	// to be appended with .<token>
 	RedisOwnSentBlocks = `solana.sent-blocks`
 
-	// EnvTokensList to relate the received token names to a contract address
-	EnvTokensList = "FLU_SOLANA_TOKENS_LIST"
-
 	// BlockPageLength is the number of confirmed blocks to fetch at once
 	BlockPageLength = 1000
 
@@ -40,6 +36,11 @@ const (
 	// A hanging websocket can duplicate blocks if this buffer is overwritten
 	// before it crashes and restarts the program
 	RedisBufferSize = 100
+)
+
+const (
+	// EnvTokensList to relate the received token names to a contract address
+	EnvTokensList = "FLU_SOLANA_TOKENS_LIST"
 
 	// EnvSolanaWsUrl is the URL to connect to the Solana websocket api
 	EnvSolanaWsUrl = `FLU_SOLANA_WS_URL`
@@ -139,7 +140,9 @@ func main() {
 			lastBlock := redis.GetLastBlock(tokenRedisKey)
 
 			// choose the lowest block of any token
-			if startingBlock == 0 || startingBlock > lastBlock {
+			shouldBeLatestBlock := startingBlock == 0 || startingBlock > lastBlock
+
+			if shouldBeLatestBlock  {
 				startingBlock = lastBlock
 			}
 		}

--- a/cmd/connector-solana-amqp/main.go
+++ b/cmd/connector-solana-amqp/main.go
@@ -8,22 +8,38 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/fluidity-money/fluidity-app/cmd/connector-solana-amqp/lib/queue"
+	"github.com/fluidity-money/fluidity-app/common/solana"
 	solanaRpc "github.com/fluidity-money/fluidity-app/common/solana/rpc"
 	"github.com/fluidity-money/fluidity-app/lib/log"
-	types "github.com/fluidity-money/fluidity-app/lib/types/solana"
+	"github.com/fluidity-money/fluidity-app/lib/state"
+
+	// types "github.com/fluidity-money/fluidity-app/lib/types/solana"
 	"github.com/fluidity-money/fluidity-app/lib/util"
 
 	"github.com/fluidity-money/fluidity-app/cmd/connector-solana-amqp/lib/redis"
 )
 
 const (
-	// RedisBlockKey is the key to find the lastest confirmed slot we've seen
-	RedisBlockKey = `solana.confirmed-blocks.latest`
+	// RedisGlobalSentBlocks for the buffer of blocks sent
+	RedisGlobalSentBlocks = `solana.sent-blocks.global`
+
+	// RedisOwnSentBlocks for the prefix of blocks seen by a given websocket,
+	// to be appended with .<token>
+	RedisOwnSentBlocks = `solana.sent-blocks`
+
+	// EnvTokensList to relate the received token names to a contract address
+	EnvTokensList = "FLU_SOLANA_TOKENS_LIST"
 
 	// BlockPageLength is the number of confirmed blocks to fetch at once
 	BlockPageLength = 1000
+
+	// RedisBufferSize is the length of the buffer for previously seen blocks
+	// A hanging websocket can duplicate blocks if this buffer is overwritten
+	// before it crashes and restarts the program
+	RedisBufferSize = 100
 
 	// EnvSolanaWsUrl is the URL to connect to the Solana websocket api
 	EnvSolanaWsUrl = `FLU_SOLANA_WS_URL`
@@ -35,6 +51,8 @@ const (
 	EnvStartingSlot = `FLU_SOLANA_STARTING_SLOT`
 )
 
+// updateConfirmedBlocksFrom to process all slots from `from`, as there is no
+// equivalent to blockSubscribe for past events
 func updateConfirmedBlocksFrom(client *solanaRpc.Provider, from uint64) (uint64, error) {
 	var lastBlock uint64 = 0
 
@@ -49,7 +67,7 @@ func updateConfirmedBlocksFrom(client *solanaRpc.Provider, from uint64) (uint64,
 			k.Format("Got confirmed blocks from solana! %+v", blocks)
 		})
 
-		queue.SendConfirmedBlocks(blocks)
+		processSlots(blocks)
 
 		if len(blocks) == 0 {
 			// we're fetching past the end
@@ -82,14 +100,17 @@ func updateConfirmedBlocksFrom(client *solanaRpc.Provider, from uint64) (uint64,
 
 func main() {
 	var (
-		solanaWsUrl  = util.PickEnvOrFatal(EnvSolanaWsUrl)
-		solanaRpcUrl = util.PickEnvOrFatal(EnvSolanaRpcUrl)
+		solanaWsUrl      = util.PickEnvOrFatal(EnvSolanaWsUrl)
+		solanaRpcUrl     = util.PickEnvOrFatal(EnvSolanaRpcUrl)
+		solanaTokenList_ = util.GetEnvOrFatal(EnvTokensList)
 	)
 
 	var (
 		startingBlock    uint64
 		startingBlockEnv = os.Getenv(EnvStartingSlot)
 	)
+
+	tokenList := solana.GetTokensListSolana(solanaTokenList_)
 
 	solanaHttp, err := solanaRpc.New(solanaRpcUrl)
 
@@ -108,36 +129,22 @@ func main() {
 			k.Payload = err
 		})
 	}
-
-	latestSlot, err := solanaHttp.GetLatestSlot()
-
-	if err != nil {
-		log.Fatal(func(k *log.Log) {
-			k.Message = "Failed to get latest slot!"
-			k.Payload = err
-		})
-	}
-
 	switch startingBlockEnv {
+	// immediately subscribe to latest blocks
 	case "latest":
-		startingBlock = latestSlot - 1
-
-		log.Debug(func(k *log.Log) {
-			k.Format("Starting from latest slot %d", latestSlot)
-		})
-
+	// default to the lowest slot saved in Redis
 	case "":
-		// default to the last slot in redis
-		startingBlock = redis.GetLastBlock(RedisBlockKey)
+		for _, token := range tokenList {
+			tokenRedisKey := RedisOwnSentBlocks + "." + token.TokenName
+			lastBlock := redis.GetLastBlock(tokenRedisKey)
 
-		log.Debug(func(k *log.Log) {
-			k.Format(
-				"Starting from last seen slot %d, max on chain is %d",
-				startingBlock,
-				latestSlot,
-			)
-		})
+			// choose the lowest block of any token
+			if startingBlock == 0 || startingBlock > lastBlock {
+				startingBlock = lastBlock
+			}
+		}
 
+	// otherwise use env
 	default:
 		startingBlock, err = strconv.ParseUint(startingBlockEnv, 10, 64)
 
@@ -151,47 +158,65 @@ func main() {
 		startingBlock = startingBlock - 1
 	}
 
-	latestBlockSeen := startingBlock - 1
+	if startingBlock != 0 {
+		log.Debug(func(k *log.Log) {
+			k.Message = "Starting block not 0, updating!"
+			k.Payload = startingBlock
+		})
+		updateConfirmedBlocksFrom(solanaHttp, startingBlock)
+	}
+
+	// use a neverending WaitGroup to avoid exiting immediately
+	var wg sync.WaitGroup
+
+	// create a websocket per token, as blockSubscribe only supports one address
+	for _, token := range tokenList {
+		tokenRedisKey := RedisOwnSentBlocks + "." + token.TokenName
+		wg.Add(1)
+		defer wg.Done()
+
+		go solanaWebsocket.SubscribeBlocks(token.FluidMintPubkey, func(b solanaRpc.BlockResponse) {
+			processSlot(tokenRedisKey, b.Value.Slot)
+		})
+	}
+
+	wg.Wait()
+}
+
+// processSlot to write a block to the queue if it hasn't been already
+func processSlot(redisKey string, slot uint64) {
+	// if redisKey is set, caller is a websocket listener 
+	if redisKey != "" {
+		redis.WriteLastBlock(redisKey, slot)
+	}
+
+	slotStr := strconv.Itoa(int(slot))
+
+	if state.ZExists(RedisGlobalSentBlocks, slotStr) {
+		log.Debug(func(k *log.Log) {
+			k.Message = "Slot already found, skipping!"
+			k.Payload = slot
+		})
+		return
+	}
 
 	log.Debug(func(k *log.Log) {
-		k.Message = "Starting to subscribe to slots..."
-		k.Payload = err
+		k.Message = "Slot doesn't exist globally, processing!"
+		k.Payload = slot
 	})
 
-	solanaWebsocket.SubscribeSlots(func(slot types.Slot) {
-		nextBlock := latestBlockSeen + 1
+	// add slot number with score as its own value
+	state.ZAddSelfScore(RedisGlobalSentBlocks, float64(slot))
 
-		log.Debug(func(k *log.Log) {
-			k.Format(
-				"Got a new slot from solana - next block is %v",
-				nextBlock,
-			)
-		})
+	// cap at RedisBufferSize values
+	state.ZRemRangeByRank(RedisGlobalSentBlocks, 0, -(RedisBufferSize + 1))
 
-		latestBlockSent, err := updateConfirmedBlocksFrom(
-			solanaHttp,
-			nextBlock,
-		)
+	queue.SendConfirmedBlocks([]uint64{slot})
+}
 
-		if err != nil {
-			log.Fatal(func(k *log.Log) {
-				k.Message = "Failed to fetch confirmed blocks!"
-				k.Payload = err
-			})
-		}
-
-		if latestBlockSent > latestBlockSeen {
-			latestBlockSeen = latestBlockSent
-
-			redis.WriteLastBlock(RedisBlockKey, latestBlockSeen)
-		} else {
-			log.App(func(k *log.Log) {
-				k.Format(
-					"Last seen block is before what we think we've sent! We can see %d, we've sent %d!",
-					latestBlockSeen,
-					latestBlockSent,
-				)
-			})
-		}
-	})
+// processSlots to process an array of slots
+func processSlots(slots []uint64) {
+	for _, slot := range slots {
+		processSlot("", slot)
+	}
 }

--- a/cmd/microservice-solana-transactions/lib/solana/rpc.go
+++ b/cmd/microservice-solana-transactions/lib/solana/rpc.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/fluidity-money/fluidity-app/lib/log"
-	types "github.com/fluidity-money/fluidity-app/lib/types/solana"
+	"github.com/fluidity-money/fluidity-app/lib/types/solana"
 )
 
 const (
@@ -37,22 +37,14 @@ var (
 )
 
 type (
-	Block struct {
-		Blockhash    string                    `json:"blockhash"`
-		Transactions []types.TransactionResult `json:"transactions"`
-	}
-	RpcError struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
 	rpcBlock struct {
-		Result Block     `json:"result"`
-		Error  *RpcError `json:"error"`
+		Result solana.Block     `json:"result"`
+		Error  *solana.RpcError `json:"error"`
 	}
 
 	// rpc return type for the getTransaction endpoint using jsonParsed encoding
 	rpcParsedJsonTransaction struct {
-		Error  *RpcError `json:"error"`
+		Error  *solana.RpcError `json:"error"`
 		Result struct {
 			Transaction struct {
 				Message struct {
@@ -66,7 +58,7 @@ type (
 )
 
 // GetBlock gets a full block by its slot
-func GetBlock(rpcUrl string, slot uint64, retries, delay int) (*Block, error) {
+func GetBlock(rpcUrl string, slot uint64, retries, delay int) (*solana.Block, error) {
 	request := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -154,7 +146,7 @@ func GetBlock(rpcUrl string, slot uint64, retries, delay int) (*Block, error) {
 	}
 }
 
-func fetchSolanaAccountList(rpcUrl string, block *Block) error {
+func fetchSolanaAccountList(rpcUrl string, block *solana.Block) error {
 	for i, txn := range block.Transactions {
 		var (
 			versionLegacyUnset = bytes.Equal(txn.Version, TransactionVersionLegacyUnset)

--- a/common/solana/rpc/subscribe-slots.go
+++ b/common/solana/rpc/subscribe-slots.go
@@ -6,9 +6,11 @@ package rpc
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/fluidity-money/fluidity-app/lib/log"
 	"github.com/fluidity-money/fluidity-app/lib/types/solana"
+	solCommon "github.com/fluidity-money/fluidity-app/common/solana"
 )
 
 // SubscribeSlots subscribes to new slots
@@ -53,4 +55,80 @@ func (websocket Websocket) SubscribeSlots(f func(solana.Slot)) {
 
 		f(slot)
 	}
+}
+
+// SubscribeBlocks to subscribe to new blocks with the given filter, if provided
+func (websocket Websocket) SubscribeBlocks(accountOrProgram solCommon.PublicKey, f func(BlockResponse)) {
+	var firstParam interface{}
+
+	if accountOrProgram.IsZero() {
+		firstParam = "all"
+	} else {
+		firstParam = struct {
+			MentionsAccountOrProgram string `json:"mentionsAccountOrProgram"`
+		} {
+			accountOrProgram.String(),
+		}
+	}
+
+	params := []interface{}{
+		firstParam,
+		struct {
+			Encoding					   string `json:"encoding"`
+			TransactionDetails			   string `json:"transactionDetails"`
+			MaxSupportedTransactionVersion int    `json:"maxSupportedTransactionVersion"`
+		}{
+			MaxSupportedTransactionVersion: 0,
+			Encoding: "jsonParsed", 
+			TransactionDetails: "none",
+		}, 
+	} 
+
+	replies := websocket.subscribe("blockSubscribe", params)
+
+	for reply := range replies {
+		result := reply.result
+
+		if err := reply.err; err != nil {
+			log.Fatal(func(k *log.Log) {
+				k.Context = LogContextWebsocket
+				k.Message = "Received error off queue for blocksSubscribe!"
+				k.Payload = err
+			})
+		}
+
+		var block BlockResponse
+
+		isEmptyMessage := len(result) == 0
+
+		if isEmptyMessage {
+			continue
+		}
+
+		// assume that the message was empty for keepalive!
+		err := json.Unmarshal(result, &block)
+
+		if err != nil {
+			log.Fatal(func(k *log.Log) {
+				k.Context = LogContextWebsocket
+
+				k.Format(
+					"Failed to decode the message %#v off the blocksSubscribe websocket!",
+					string(result),
+				)
+
+				k.Payload = err
+			})
+		}
+
+		f(block)
+	}
+}
+
+type BlockResponse struct {
+	Value struct {
+		Slot  uint64		   `json:"slot"`
+		Error *solana.RpcError `json:"err"`
+		Block solana.Block     `json:"block"`
+	} `json:"value"`
 }

--- a/common/solana/rpc/subscribe-slots.go
+++ b/common/solana/rpc/subscribe-slots.go
@@ -6,7 +6,6 @@ package rpc
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/fluidity-money/fluidity-app/lib/log"
 	"github.com/fluidity-money/fluidity-app/lib/types/solana"

--- a/lib/state/state.go
+++ b/lib/state/state.go
@@ -116,6 +116,37 @@ func RPush(key string, content interface{}) {
 	}
 }
 
+func ZAdd(key string, content *redis.Z) {
+	redisClient := client()
+
+	intCmd := redisClient.ZAdd(context.Background(), key, content)
+
+	if err := intCmd.Err(); err != nil {
+		log.Fatal(func(k *log.Log) {
+			k.Context = Context
+			k.Message = "Failed to ZAdd key!"
+			k.Payload = err
+		})
+	}
+}
+
+func ZAddSelfScore(key string, content float64) {
+	redisClient := client()
+
+	intCmd := redisClient.ZAdd(context.Background(), key, &redis.Z{
+		Score: content, 
+		Member: content,
+	})
+
+	if err := intCmd.Err(); err != nil {
+		log.Fatal(func(k *log.Log) {
+			k.Context = Context
+			k.Message = "Failed to ZAdd key!"
+			k.Payload = err
+		})
+	}
+}
+
 func ZRem(key, member string) {
 	redisClient := client()
 
@@ -128,6 +159,51 @@ func ZRem(key, member string) {
 			k.Payload = err
 		})
 	}
+}
+
+func ZRemRangeByRank(key string, start, stop int64) {
+	redisClient := client()
+
+	intCmd := redisClient.ZRemRangeByRank(context.Background(), key, start, stop)
+
+	if err := intCmd.Err(); err != nil {
+		log.Fatal(func(k *log.Log) {
+			k.Context = Context
+			k.Message = "Failed to ZRemRangeByRank!"
+			k.Payload = err
+		})
+	}
+}
+
+func ZScore(key, member string) float64 {
+	redisClient := client()
+
+	stringCmd := redisClient.ZScore(context.Background(), key, member)
+
+	score , err := stringCmd.Result()
+
+	if err != nil && err != redis.Nil {
+		log.Fatal(func(k *log.Log) {
+			k.Context = Context
+
+			k.Format(
+				"Failed to ZScore from key %v and convert to bytes!",
+				key,
+			)
+
+			k.Payload = err
+		})
+	}
+
+	if err == redis.Nil {
+		return 0
+	}
+
+	return score
+}
+
+func ZExists(key, member string) bool {
+	return ZScore(key, member) > 0
 }
 
 // ZPeep looks at the first member of a sorted set without popping it

--- a/lib/types/solana/solana.go
+++ b/lib/types/solana/solana.go
@@ -148,6 +148,15 @@ type (
 		Data           string `json:"data"`
 		ProgramIdIndex int    `json:"programIdIndex"`
 	}
+
+	Block struct {
+		Blockhash    string                    `json:"blockhash"`
+		Transactions []TransactionResult `json:"transactions"`
+	}
+	RpcError struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
 )
 
 // Slot is the type that logs the current slot as sent by the solana RPC


### PR DESCRIPTION
- update `connector-solana-amqp` to use `blockSubscribe` instead of `slotSubscribe` to enable per-account filtering and only fetch relevant blocks
- use concurrent websockets to `blockSubscribe` to multiple addresses
- synchronise sent blocks with a Redis sorted set