### PR TITLE
Fix iOS Scroll Issue

### DIFF
--- a/web/fluidity.money/src/styles/app.global.scss
+++ b/web/fluidity.money/src/styles/app.global.scss
@@ -91,7 +91,6 @@ button {
 }
 
 #root {
-  position: absolute;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Fixes scroll behavior on iOS devices. Having `position:absolute` led to body element having a height of 0 causing glitch.

Verification 

https://drive.google.com/file/d/1x1rY9lc33cIePpIEw-9rD0mqlI9ydTJK/view?usp=drive_link