### PR TITLE
use solana owners for aggregated transactions

### DIFF
--- a/cmd/microservice-user-transactions-aggregate/main.go
+++ b/cmd/microservice-user-transactions-aggregate/main.go
@@ -32,7 +32,7 @@ func main() {
 			user_actions.InsertAggregatedUserTransaction(userTransaction)
 			// corresponding pending win has already been seen, so set user action specific fields
 		} else if existingUserTransaction.RecipientAddress == "" {
-			// use aggregate function to scale amount to dollars
+			// use aggregate function to scale amount to dollars and convert solana addresses
 			userTransaction := userActionsType.AggregatedTransactionFromUserAction(userAction)
 
 			existingUserTransaction.Time = userAction.Time

--- a/lib/types/user-actions/user-actions.go
+++ b/lib/types/user-actions/user-actions.go
@@ -97,8 +97,12 @@ type (
 
 		TransactionHash string `json:"transaction_hash"`
 
+		// SenderAddress is the owner of the ATA that sent this transaction on Solana
+		// and the normal sender address on other networks
 		SenderAddress string `json:"sender_address"`
 
+		// RecipientAddress is the owner of the ATA that received this transaction on Solana
+		// and the normal sender address on other networks
 		RecipientAddress string `json:"recipient_address"`
 
 		// scaled to usd
@@ -128,6 +132,20 @@ type (
 
 // AggregatedTransactionFromUserAction to create a partially aggregated transaction from a user action
 func AggregatedTransactionFromUserAction(userAction UserAction) AggregatedUserTransaction {
+	var (	
+		senderAddress    string
+		recipientAddress string
+	)
+
+	// replace ATAs with their owners
+	if userAction.Network == network.NetworkSolana {
+		senderAddress = userAction.SolanaSenderOwnerAddress
+		recipientAddress = userAction.SolanaRecipientOwnerAddress
+	} else {
+		senderAddress = userAction.SenderAddress
+		recipientAddress = userAction.RecipientAddress
+	}
+
 	// convert amount to a dollar float
 	decimalsAdjusted := math.Pow10(userAction.TokenDetails.TokenDecimals)
 	decimalsRat := new(big.Rat).SetFloat64(decimalsAdjusted)
@@ -143,8 +161,8 @@ func AggregatedTransactionFromUserAction(userAction UserAction) AggregatedUserTr
 		Type:             userAction.Type,
 		SwapIn:           userAction.SwapIn,
 		TransactionHash:  userAction.TransactionHash,
-		SenderAddress:    userAction.SenderAddress,
-		RecipientAddress: userAction.RecipientAddress,
+		SenderAddress:    senderAddress,
+		RecipientAddress: recipientAddress,
 	}
 }
 


### PR DESCRIPTION
- replace winner/sender/recipient ATAs with their owner addresses for Solana transactions in the aggregate table