### PR TITLE
Enable docker image test

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -3,4 +3,8 @@ FROM fluidity/build-container:latest
 
 RUN go mod download
 
+COPY .semgrep .semgrep
+
+COPY tests tests
+
 ENTRYPOINT make test

--- a/Dockerfile.testing.dockerignore
+++ b/Dockerfile.testing.dockerignore
@@ -1,0 +1,25 @@
+.git
+cmd
+web
+contracts
+automation
+!automation/nginx-default.conf
+docs
+
+**/*.o
+**/*.out
+*.out
+*.o
+
+lib/build-lib
+common/build-common
+
+database/build/**
+database/build
+database/db
+
+deployment_list.json
+
+# Vendor specific
+.vscode
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ AUTOMATION_DIR := automation
 	test \
 	test-go \
 	test-contracts \
+        test-docker \
 	docker-test \
 	install
 
@@ -93,6 +94,15 @@ docker-node: docker-build
 
 	@touch docker-node
 
+docker-testing: docker
+	@${DOCKER_BUILD} \
+		${DOCKERFLAGS} \
+		-t ${ORG_ROOT}/docker-testing-container \
+		-f Dockerfile.testing \
+		.
+
+	@touch docker-test
+
 docker: \
 	docker-root \
 	docker-root-web \
@@ -102,8 +112,8 @@ docker: \
 	docker-build-web \
 	docker-node
 
-docker-test: docker
-	@${DOCKER_RUN} -f Dockerfile.test
+test-docker: docker-testing
+	@${DOCKER_RUN} ${ORG_ROOT}/docker-testing-container
 
 docker-compose-build:
 	@./scripts/docker-compose-all.sh build

--- a/build.mk
+++ b/build.mk
@@ -13,6 +13,7 @@ NPM_INSTALL := npm install
 
 DOCKER_BUILD := docker build
 DOCKER_COMPOSE := docker-compose
+DOCKER_RUN := docker run
 
 SEMGREP_ALL := semgrep --config p/ci --config p/secrets
 


### PR DESCRIPTION
Initial fixes to enable the docker testing image.
Run tests with command:
```shell
make test-docker
```

The tests require a Redis instance, and a Postgres instance.
Some test shell scripts require the image to have `jq`, and another requires `aws-cli`, which will need zone configuration.  
