### PR TITLE
rework airdrop leaderboard

### DIFF
--- a/database/102-up-timescale/20240411121113-airdrop_leaderboard_group_coalesce.sql
+++ b/database/102-up-timescale/20240411121113-airdrop_leaderboard_group_coalesce.sql
@@ -1,0 +1,103 @@
+-- migrate:up
+
+DROP FUNCTION airdrop_leaderboard;
+
+CREATE FUNCTION airdrop_leaderboard(epoch_ lootbox_epoch)
+ RETURNS SETOF airdrop_leaderboard_return
+ LANGUAGE sql
+ STABLE
+AS $function$
+SELECT
+    DISTINCT lb.address as address,
+    ROW_NUMBER() OVER () AS rank,
+    COUNT(DISTINCT referee) AS referral_count,
+    lb.total_box_count,
+    lb.highest_reward_tier,
+    COALESCE(liquidity.result, 1) AS liquidity_multiplier,
+    COALESCE(SUM(lootbox_amounts_rewarded_fusdc.amount_earned), 0),
+    COALESCE(SUM(lootbox_amounts_rewarded_arb.amount_earned), 0),
+    fly_staked.amount AS fly_staked
+FROM (
+    -- subquery to avoid re-summing lootbox_count for every referee
+    SELECT address, SUM(lootbox_count) as total_box_count, MAX(reward_tier) as highest_reward_tier
+    FROM lootbox
+    WHERE epoch = epoch_
+    GROUP BY address
+) lb
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'USDC' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_fusdc ON lb.address = lootbox_amounts_rewarded_fusdc.winner
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'ARB' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_arb ON lb.address = lootbox_amounts_rewarded_arb.winner
+    LEFT JOIN lootbox_referrals
+        ON lb.address = lootbox_referrals.referrer
+    LEFT JOIN fly_staked
+       ON lb.address = fly_staked.address,
+    LATERAL calculate_a_y(lb.address, now()::TIMESTAMP) AS liquidity
+GROUP BY
+    lb.address,
+    liquidity_multiplier,
+    total_box_count,
+    highest_reward_tier,
+    fly_staked.address,
+    fly_staked.amount
+$function$;
+
+
+-- migrate:down
+
+DROP FUNCTION airdrop_leaderboard;
+
+CREATE FUNCTION airdrop_leaderboard(epoch_ lootbox_epoch)
+ RETURNS SETOF airdrop_leaderboard_return
+ LANGUAGE sql
+ STABLE
+AS $function$
+SELECT
+    DISTINCT lb.address as address,
+    ROW_NUMBER() OVER () AS rank,
+    COUNT(DISTINCT referee) AS referral_count,
+    lb.total_box_count,
+    lb.highest_reward_tier,
+    COALESCE(liquidity.result, 1) AS liquidity_multiplier,
+    COALESCE(lootbox_amounts_rewarded_fusdc.amount_earned, 0),
+    COALESCE(lootbox_amounts_rewarded_fly.amount_earned, 0),
+    fly_staked.amount AS fly_staked
+FROM (
+    -- subquery to avoid re-summing lootbox_count for every referee
+    SELECT address, SUM(lootbox_count) as total_box_count, MAX(reward_tier) as highest_reward_tier
+    FROM lootbox
+    WHERE epoch = epoch_
+    GROUP BY address
+) lb
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'USDC' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_fusdc ON lb.address = lootbox_amounts_rewarded_fusdc.winner
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'FLY' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_fly ON lb.address = lootbox_amounts_rewarded_fly.winner
+    LEFT JOIN lootbox_referrals
+        ON lb.address = lootbox_referrals.referrer
+    LEFT JOIN fly_staked
+       ON lb.address = fly_staked.address,
+    LATERAL calculate_a_y(lb.address, now()::TIMESTAMP) AS liquidity
+GROUP BY
+    lb.address,
+    liquidity_multiplier,
+    total_box_count,
+    highest_reward_tier,
+    lootbox_amounts_rewarded_fusdc.amount_earned,
+    lootbox_amounts_rewarded_fly.amount_earned,
+    fly_staked.address,
+    fly_staked.amount
+$function$;
+

--- a/database/102-up-timescale/20240411122107-airdrop_leaderboard_24_group_coalesce.sql
+++ b/database/102-up-timescale/20240411122107-airdrop_leaderboard_24_group_coalesce.sql
@@ -1,0 +1,99 @@
+-- migrate:up
+
+CREATE OR REPLACE FUNCTION airdrop_leaderboard_24_hours(epoch_ lootbox_epoch)
+ RETURNS SETOF airdrop_leaderboard_return
+ LANGUAGE sql
+ STABLE
+AS $function$
+SELECT
+    lb.address,
+    -- placeholder
+    ROW_NUMBER() OVER () AS rank,
+    COUNT(DISTINCT referee) AS referral_count,
+    lb.total_box_count,
+    lb.highest_reward_tier,
+    COALESCE(liquidity.result, 1) AS liquidity_multiplier,
+    COALESCE(SUM(lootbox_amounts_rewarded_fusdc.amount_earned), 0),
+    COALESCE(SUM(lootbox_amounts_rewarded_arb.amount_earned), 0),
+    fly_staked.amount AS fly_staked
+FROM (
+    -- subquery to avoid re-summing lootbox_count for every referee
+    SELECT address, SUM(lootbox_count) as total_box_count, MAX(reward_tier) as highest_reward_tier
+    FROM lootbox
+    WHERE awarded_time > now() - interval '1 day' AND epoch = epoch_
+    GROUP BY address
+) lb
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'USDC' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_fusdc ON lb.address = lootbox_amounts_rewarded_fusdc.winner
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'ARB' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_arb ON lb.address = lootbox_amounts_rewarded_arb.winner
+    LEFT JOIN lootbox_referrals
+        ON lb.address = lootbox_referrals.referrer
+    LEFT JOIN fly_staked
+        ON lb.address = fly_staked.address,
+    LATERAL calculate_a_y(lb.address, now()::TIMESTAMP) AS liquidity
+GROUP BY
+    lb.address,
+    liquidity_multiplier,
+    total_box_count,
+    highest_reward_tier,
+    fly_staked.address,
+    fly_staked.amount
+$function$;
+
+-- migrate:down
+
+CREATE OR REPLACE FUNCTION airdrop_leaderboard_24_hours(epoch_ lootbox_epoch)
+ RETURNS SETOF airdrop_leaderboard_return
+ LANGUAGE sql
+ STABLE
+AS $function$
+SELECT
+    lb.address,
+    -- placeholder
+    ROW_NUMBER() OVER () AS rank,
+    COUNT(DISTINCT referee) AS referral_count,
+    lb.total_box_count,
+    lb.highest_reward_tier,
+    COALESCE(liquidity.result, 1) AS liquidity_multiplier,
+    COALESCE(lootbox_amounts_rewarded_fusdc.amount_earned, 0),
+    COALESCE(lootbox_amounts_rewarded_arb.amount_earned, 0),
+	fly_staked.amount AS fly_staked
+FROM (
+    -- subquery to avoid re-summing lootbox_count for every referee
+    SELECT address, SUM(lootbox_count) as total_box_count, MAX(reward_tier) as highest_reward_tier
+    FROM lootbox
+    WHERE awarded_time > now() - interval '1 day' AND epoch = epoch_
+    GROUP BY address
+) lb
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'USDC' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_fusdc ON lb.address = lootbox_amounts_rewarded_fusdc.winner
+    LEFT JOIN (
+        SELECT amount_earned, winner
+        FROM lootbox_amounts_rewarded
+        WHERE token_short_name = 'ARB' AND epoch = epoch_
+    ) AS lootbox_amounts_rewarded_arb ON lb.address = lootbox_amounts_rewarded_arb.winner
+    LEFT JOIN lootbox_referrals
+        ON lb.address = lootbox_referrals.referrer
+    LEFT JOIN fly_staked
+        ON lb.address = fly_staked.address,
+    LATERAL calculate_a_y(lb.address, now()::TIMESTAMP) AS liquidity
+GROUP BY
+    lb.address,
+    liquidity_multiplier,
+    total_box_count,
+    highest_reward_tier,
+    lootbox_amounts_rewarded_fusdc.amount_earned,
+    lootbox_amounts_rewarded_arb.amount_earned,
+    fly_staked.address,
+    fly_staked.amount
+$function$;

--- a/lib/types/worker/emissions_test.go
+++ b/lib/types/worker/emissions_test.go
@@ -37,6 +37,7 @@ func TestString(t *testing.T) {
 	"sender_address":"",
 	"ethereum_block_number":"0",
 	"solana_slot_number":"0",
+	"sui_checkpoint_number":"0",
 	"average_transfers_in_block":0,
 	"atx_buffer_size":0,
 	"transfers_in_block":0,
@@ -109,6 +110,7 @@ func TestString(t *testing.T) {
 		"betswirl": 0,
 		"paraswap": 0
 	},
+	"sui_fees":{},
 	"calculate_n":{
 		"probability_m":0,
 		"factorial":0,

--- a/lib/util/token-list.go
+++ b/lib/util/token-list.go
@@ -40,7 +40,7 @@ func NewTokenDetailsBase(address, name string, decimals int, extras ...string) T
 		TokenAddress:  address,
 		TokenName:     name,
 		TokenDecimals: decimalsRat,
-		Extras:         extras,
+		Extras:        extras,
 	}
 }
 
@@ -68,7 +68,7 @@ func GetTokensListBase(tokensList_ string) []TokenDetailsBase {
 			tokenAddress = trimWhitespace(tokenDetails_[0])
 			tokenName    = trimWhitespace(tokenDetails_[1])
 			decimals_    = trimWhitespace(tokenDetails_[2])
-			extras        = tokenDetails_[3:]
+			extras       = tokenDetails_[3:]
 		)
 
 		decimals, err := strconv.Atoi(decimals_)

--- a/lib/util/token-list_test.go
+++ b/lib/util/token-list_test.go
@@ -30,26 +30,32 @@ func TestTokenList(t *testing.T) {
 		{
 			TokenName:     `USDT`,
 			TokenDecimals: big.NewRat(1000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `USDC`,
 			TokenDecimals: big.NewRat(1000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `DAI`,
 			TokenDecimals: big.NewRat(1000000000000000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `TUSD`,
 			TokenDecimals: big.NewRat(1000000000000000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `FEI`,
 			TokenDecimals: big.NewRat(1000000000000000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `FRAX`,
 			TokenDecimals: big.NewRat(1000000000000000000, 1),
+			Extras:        []string{},
 		},
 	}
 
@@ -57,14 +63,17 @@ func TestTokenList(t *testing.T) {
 		{
 			TokenName:     `USDC`,
 			TokenDecimals: big.NewRat(1000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `USDT`,
 			TokenDecimals: big.NewRat(1000000, 1),
+			Extras:        []string{},
 		},
 		{
 			TokenName:     `UXD`,
 			TokenDecimals: big.NewRat(1000000, 1),
+			Extras:        []string{},
 		},
 	}
 

--- a/web/app.fluidity.money/app/queries/useAirdropLeaderboard.ts
+++ b/web/app.fluidity.money/app/queries/useAirdropLeaderboard.ts
@@ -67,21 +67,8 @@ type AirdropLeaderboardBody = {
   query: string;
 };
 
-type AirdropLeaderboardByUserBody = AirdropLeaderboardBody & {
-  variables: {
-    address: string;
-  };
-};
-
 type AirdropLeaderboardByApplicationBody = AirdropLeaderboardBody & {
   variables: {
-    application: string;
-  };
-};
-
-type AirdropLeaderboardByUserByApplicationBody = AirdropLeaderboardBody & {
-  variables: {
-    address: string;
     application: string;
   };
 };

--- a/web/app.fluidity.money/app/queries/useAirdropLeaderboard.ts
+++ b/web/app.fluidity.money/app/queries/useAirdropLeaderboard.ts
@@ -1,50 +1,11 @@
 import { jsonPost, gql, fetchInternalEndpoint } from "~/util";
 
-const queryByUserAllTime = gql`
-  query AirdropLeaderboard($epoch: lootbox_epoch!, $address: String!)
-  @cached(ttl: 120) {
-    airdrop_leaderboard(
-      args: { epoch_: $epoch }
-      where: { address: { _eq: $address } }
-      limit: 1
-    ) {
-      user: address
-      rank
-      referralCount: referral_count
-      bottles: total_lootboxes
-      highestRewardTier: highest_reward_tier
-      liquidityMultiplier: liquidity_multiplier
-    }
-  }
-`;
-
 const queryAllTime = gql`
   query AirdropLeaderboard($epoch: lootbox_epoch!) @cached(ttl: 120) {
     airdrop_leaderboard(
       args: { epoch_: $epoch }
-      limit: 16
+      limit: 1000
       order_by: { total_lootboxes: desc }
-    ) {
-      user: address
-      rank
-      referralCount: referral_count
-      bottles: total_lootboxes
-      highestRewardTier: highest_reward_tier
-      liquidityMultiplier: liquidity_multiplier
-      fusdcEarned: fusdc_earned
-      arbEarned: arb_earned
-      flyStaked: fly_staked
-    }
-  }
-`;
-
-const queryByUser24Hours = gql`
-  query AirdropLeaderboard($epoch: lootbox_epoch!, $address: String!)
-  @cached(ttl: 60) {
-    airdrop_leaderboard: airdrop_leaderboard_24_hours(
-      args: { epoch_: $epoch }
-      where: { address: { _eq: $address } }
-      limit: 1
     ) {
       user: address
       rank
@@ -63,32 +24,8 @@ const query24Hours = gql`
   query AirdropLeaderboard($epoch: lootbox_epoch!) @cached(ttl: 120) {
     airdrop_leaderboard: airdrop_leaderboard_24_hours(
       args: { epoch_: $epoch }
-      limit: 16
+      limit: 1000
       order_by: { total_lootboxes: desc }
-    ) {
-      user: address
-      rank
-      referralCount: referral_count
-      bottles: total_lootboxes
-      highestRewardTier: highest_reward_tier
-      liquidityMultiplier: liquidity_multiplier
-      fusdcEarned: fusdc_earned
-      arbEarned: arb_earned
-      flyStaked: fly_staked
-    }
-  }
-`;
-
-const query24HoursByUserByApplication = gql`
-  query AirdropLeaderboardApplication(
-    $epoch: lootbox_epoch!
-    $application: ethereum_application!
-    $address: String!
-  ) @cached(ttl: 120) {
-    airdrop_leaderboard: airdrop_leaderboard_24_hours_by_application(
-      args: { epoch_: $epoch, application_: $application }
-      where: { address: { _eq: $address } }
-      limit: 1
     ) {
       user: address
       rank
@@ -110,7 +47,7 @@ const query24HoursByApplication = gql`
   ) @cached(ttl: 120) {
     airdrop_leaderboard: airdrop_leaderboard_24_hours_by_application(
       args: { epoch_: $epoch, application_: $application }
-      limit: 16
+      limit: 1000
       order_by: { total_lootboxes: desc }
     ) {
       user: address
@@ -168,28 +105,6 @@ type AirdropLeaderboardResponse = {
   errors?: unknown;
 };
 
-export const useAirdropLeaderboardByUserAllTime = (
-  epoch: string,
-  address: string
-) => {
-  const { url, headers } = fetchInternalEndpoint();
-
-  const variables = {
-    epoch,
-    address,
-  };
-  const body = {
-    query: queryByUserAllTime,
-    variables,
-  };
-
-  return jsonPost<AirdropLeaderboardByUserBody, AirdropLeaderboardResponse>(
-    url,
-    body,
-    headers
-  );
-};
-
 export const useAirdropLeaderboardAllTime = (epoch: string) => {
   const { url, headers } = fetchInternalEndpoint();
   const variables = { epoch };
@@ -199,28 +114,6 @@ export const useAirdropLeaderboardAllTime = (epoch: string) => {
   };
 
   return jsonPost<AirdropLeaderboardBody, AirdropLeaderboardResponse>(
-    url,
-    body,
-    headers
-  );
-};
-
-export const useAirdropLeaderboardByUser24Hours = (
-  epoch: string,
-  address: string
-) => {
-  const { url, headers } = fetchInternalEndpoint();
-
-  const variables = {
-    address,
-    epoch,
-  };
-  const body = {
-    query: queryByUser24Hours,
-    variables,
-  };
-
-  return jsonPost<AirdropLeaderboardByUserBody, AirdropLeaderboardResponse>(
     url,
     body,
     headers
@@ -240,29 +133,6 @@ export const useAirdropLeaderboard24Hours = (epoch: string) => {
     body,
     headers
   );
-};
-
-export const useAirdropLeaderboardByUserByApplication24Hours = (
-  epoch: string,
-  address: string,
-  application: string
-) => {
-  const { url, headers } = fetchInternalEndpoint();
-
-  const variables = {
-    epoch,
-    address,
-    application,
-  };
-  const body = {
-    query: query24HoursByUserByApplication,
-    variables,
-  };
-
-  return jsonPost<
-    AirdropLeaderboardByUserByApplicationBody,
-    AirdropLeaderboardResponse
-  >(url, body, headers);
 };
 
 export const useAirdropLeaderboardByApplication24Hours = (

--- a/web/app.fluidity.money/app/routes/$network/dashboard/airdrop/index.tsx
+++ b/web/app.fluidity.money/app/routes/$network/dashboard/airdrop/index.tsx
@@ -505,16 +505,27 @@ const Airdrop = () => {
   const isMobile = width < mobileBreakpoint;
 
   const { data: airdropData } = useCache<AirdropLoaderData>(
-      `/${network}/query/dashboard/airdrop?epoch=${EPOCH_CURRENT_IDENTIFIER}&address=${address}`
+    address
+      ? `/${network}/query/dashboard/airdrop?address=${address}&epoch=${EPOCH_CURRENT_IDENTIFIER}`
+      : ""
   );
 
   const currentApplication = "";
 
-  const { data: airdropLeaderboardData } = useCache<AirdropLoaderData>(
+  const { data: airdropLeaderboardData_ } = useCache<AirdropLeaderboardLoaderData>(
     `/${network}/query/dashboard/airdropLeaderboard?period=${leaderboardFilterIndex === 0 ? "24" : "all"
-    }${leaderboardFilterIndex === 0 ? `&provider=${currentApplication}` : ""
+    }&address=${address ?? ""}${leaderboardFilterIndex === 0 ? `&provider=${currentApplication}` : ""
     }&epoch=${EPOCH_CURRENT_IDENTIFIER}`
   );
+
+  // airdrop leaderboard data contains more than the displayed entries, so postprocessing is required
+  const airdropLeaderboardData = useMemo(() => ({
+    loaded: airdropLeaderboardData_?.loaded,
+    leaderboard: getLeaderboardWithUser(
+      airdropLeaderboardData_?.leaderboard || [], 
+      address ?? ""
+    )
+  }), [airdropLeaderboardData_])
 
   const { data: referralData } = useCache<AirdropLoaderData>(
     address
@@ -1932,5 +1943,38 @@ export const dayDifference = (date1: Date, date2: Date) =>
 
 const isAirdropModal = (modal: string): modal is AirdropModalName =>
   AIRDROP_MODALS.includes(modal as AirdropModalName);
+
+// filter airdrop leaderboard data to the top 16 and the current user if the're found
+const getLeaderboardWithUser = (data: Array<AirdropLeaderboardEntry>, address: string) => {
+  const top16 = data.slice(0, 16)
+
+  // user not logged in
+  if (!address)
+    return top16
+
+  const userDataIndex = data.findIndex(({user}) => user === address)
+
+  // user not found in data, use a blank entry
+  if (userDataIndex === -1)
+    return [
+        {
+          user: address,
+          rank: -1,
+          liquidityMultiplier: 0,
+          referralCount: 0,
+          bottles: 0,
+          highestRewardTier: 0,
+          fusdcEarned: 0,
+          arbEarned: 0,
+          flyStaked: 0
+        } satisfies AirdropLeaderboardEntry,
+      ].concat(top16)
+  // found outside the top 16
+  if (userDataIndex >= 16) {
+    return [data[userDataIndex]].concat(top16)
+  }
+  // found in the top 16
+  return top16
+}
 
 export default Airdrop;

--- a/web/app.fluidity.money/app/routes/$network/dashboard/airdrop/index.tsx
+++ b/web/app.fluidity.money/app/routes/$network/dashboard/airdrop/index.tsx
@@ -1004,7 +1004,7 @@ const Airdrop = () => {
           {currentModal === "leaderboard" && (
             <>
               <Leaderboard
-                loaded={leaderboardLoaded}
+                loaded={leaderboardLoaded ?? false}
                 data={leaderboardRows}
                 filterIndex={leaderboardFilterIndex}
                 setFilterIndex={setLeaderboardFilterIndex}
@@ -1319,7 +1319,7 @@ const Airdrop = () => {
               color="white"
             >
               <Leaderboard
-                loaded={leaderboardLoaded}
+                loaded={leaderboardLoaded ?? false}
                 data={leaderboardRows}
                 filterIndex={leaderboardFilterIndex}
                 setFilterIndex={setLeaderboardFilterIndex}


### PR DESCRIPTION
- fix bug in query where entries were duplicated on `fusdc_earned` and `arb_earned` columns rather than summing
- improve performance by replacing per-user query with large cacheable query and clientside filtering